### PR TITLE
bamqccram new ECR host

### DIFF
--- a/modules/nf-core/qualimap/bamqccram/main.nf
+++ b/modules/nf-core/qualimap/bamqccram/main.nf
@@ -5,7 +5,7 @@ process QUALIMAP_BAMQCCRAM {
     conda "bioconda::qualimap=2.2.2d bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-d3934ca6bb4e61334891ffa2e9a4c87a530e3188:00d3c18496ddf07ea580fd00d1dd203cf31ab630-0' :
-        'biocontainers/mulled-v2-d3934ca6bb4e61334891ffa2e9a4c87a530e3188:00d3c18496ddf07ea580fd00d1dd203cf31ab630-0' }"
+        '075615082992.dkr.ecr.us-west-2.amazonaws.com/qaulimap_bamqccram:latest' }"
 
     input:
     tuple val(meta), path(cram), path(crai)


### PR DESCRIPTION
New container location for the `QUALIMAP_BAMQCCRAM` process downloaded from QUAY and now hosted on ECR

@zaki-bds, once we get a successful run with no docker timeouts or nextflow resumes, let's make a PR to master 😉  